### PR TITLE
PR 라벨링 및 리뷰어 등록 자동화

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@ Frontend/ @HyeryongChoi @hae-on
 Backend/ @HASEUNGHEEE
 Data/ @enxxo
 
-.github/ @HyeryongChoi @hae-on @HASEUNGHEEE @enxxo
+.github/ @INDIE-RO/sync

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+Frontend/ @HyeryongChoi @hae-on
+Backend/ @HASEUNGHEEE
+Data/ @enxxo
+
+.github/ @HyeryongChoi @hae-on @HASEUNGHEEE @enxxo

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,15 @@
+🍳 Frontend:
+- changed-files:
+	- any-glob-to-any-file: 'Frontend/**/*'
+🚀 Backend:
+- changed-files:
+	- any-glob-to-any-file: 'Backend/**/*'
+🧢 Data:
+- changed-files:
+	- any-glob-to-any-file: 'Data/**/*'
+✨ Feature:
+	- head-branch: ['^feat', 'feat']
+🐛 Bug Report:
+	- head-branch: ['^hotfix', 'hotfix', '^fix', 'fix']
+🛫 Release:
+	- base-branch: 'main'

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,17 @@
+name: 'Pull Request Labeler'
+on:
+  pull_request_target: # PR이 open(reopen) 되거나 새로운 commit push된 경우
+    types: [opened, reopened, synchronize]
+
+jobs:
+  triage:
+    permissions: # workflows 권한 지정
+      contents: read # 레포 읽기 권한
+      pull-requests: write # PR 쓰기 권한
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Labels
+        uses: actions/labeler@v5 # actions/labeler@v5 사용
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          sync-labels: true # 규칙에 맞지 않는 라벨 제거


### PR DESCRIPTION
## Issue

- close #12 

## ✨ 구현한 기능
PR 올릴 때마다 라벨링이랑 리뷰어 설정 하는 게 귀찮아서
[actions/labeler](https://github.com/actions/labeler/blob/main/README.md)를 참고하여 PR 라벨링 자동화 워크플로우 작성하고 CODEOWNERS를 추가했습니다.

(라벨에 이모지가 들어가서 제대로 작동할지는 모르겠네요..?ㅎㅎ)

- [x] PR 라벨링 자동화 워크플로우 추가 

```
# .github/workflows/label.yml

name: "Pull Request Labeler"
on: # 액션 작동 조건
    pull_request_target: # PR이 open(reopen) 되거나 새로운 commit push된 경우
	    types: [opened, reopened, synchronize]

jobs:
    triage:
        permissions:        # workflows 권한 지정
            contents: read       # 레포 읽기 권한
            pull-requests: write # PR 쓰기 권한
    runs-on: ubuntu-latest
    steps:
        - name: Check Labels
	  uses: actions/labeler@v4 # actions/labeler@v4 사용
          with:
              repo-token: "${{ secrets.GITHUB_TOKEN }}"
              sync-labels: true      # 규칙에 맞지 않는 라벨 제거
```

```
# .github/labeler.yml

🍳 Frontend:
- changed-files:
    - any-glob-to-any-file: 'Frontend/**/*'
🚀 Backend:
- changed-files:
    - any-glob-to-any-file: 'Backend/**/*'
🧢 Data:
- changed-files:
    - any-glob-to-any-file: 'Data/**/*'
✨ Feature:
    - head-branch: ['^feat', 'feat']
🐛 Bug Report:
    - head-branch: ['^hotfix', 'hotfix', '^fix', 'fix']
🛫 Release:
    - base-branch: 'main'
```
- `Frontend` 라벨은 Frontend 하위 폴더에서 변화가 있을 경우 추가합니다.
- `Backend` 라벨은 Backend 하위 폴더에서 변화가 있을 경우 추가합니다.
- `Data` 라벨은 Data 하위 폴더에서 변화가 있을 경우 추가합니다.
- `Feature` 라벨은 head branch 명에 ‘feat’이 포함된 경우 추가합니다.
- `Bug Report` 라벨은 head branch 명에 ‘fix’ 또는 ‘hotfix’가 포함된 경우 추가합니다.
- `Release` 라벨은 main branch에 PR이 open될 경우 추가합니다.


- [x] CODEOWNERS 설정을 통한 리뷰어 등록 자동화
```
# .github/CODEOWNERS

Frontend/ @HyeryongChoi @hae-on
Backend/ @HASEUNGHEEE
Data/ @enxxo

.github/ @INDIE-RO/sync
```
- `Frontend/` 폴더의 내용이 변경되면 프론트 팀원이 리뷰어로 등록,
- `Backend/` 폴더의 내용이 변경되면 백엔드 팀원이 리뷰어로 등록,
- `Data/` 폴더의 내용이 변경되면 데이터분석 팀원이 리뷰어로 등록,
- `.github/` 폴더의 내용이 변경되면 팀원 모두가 리뷰어로 등록되도록 설정했습니다.

## 🎸기타
- @enxxo 님 멤버 초대 받아주세용
