### PR TITLE
chore: PR Assignees 등록 워크플로우 추가

### DIFF
--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -1,0 +1,15 @@
+name: 'PR Auto Assign'
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: hkusu/review-assign-action@v1
+        with:
+          assignees: ${{ github.actor }} # PR 요청자를 Assignees로 할당
+          max-num-of-reviewers: 1 # 리뷰어가 랜덤으로 선택되어 할당
+          ready-comment: 'Ready for review :ok: `<reviewers>`' # if there are reviewers, posted when opened or draft is released
+          merged-comment: 'It was merged. Thanks for your review :wink: `<reviewers>`' # if reviewed, posted when merged


### PR DESCRIPTION
## Issue

- close #16 

## ✨ 구현한 기능

- [x] PR 생성 시 PR 요청자를 Assignees로 등록합니다.

```yml
# .github/workflows/pr-auto-assign.yml

name: "PR Auto Assign"
on:
  pull_request:
    types: [opened, ready_for_review]

jobs:
  assign:
    runs-on: ubuntu-latest
    steps:
      - uses: hkusu/review-assign-action@v1
        with:
          assignees: ${{ github.actor }} # PR 요청자를 Assignees로 할당
          max-num-of-reviewers: 1 # 리뷰어가 랜덤으로 선택되어 할당
          ready-comment: 'Ready for review :ok: `<reviewers>`' # if there are reviewers, posted when opened or draft is released
          merged-comment: 'It was merged. Thanks for your review :wink: `<reviewers>`' # if reviewed, posted when merged

```

## 📢 논의하고 싶은 내용

@HASEUNGHEEE , @enxxo 백엔드, 데이터 팀원은 각각 1명씩이라서 `max-num-of-reviewers`를 1로 설정해두고 한 명의 리뷰어가 랜덤으로 선택되어 할당되도록 설정했습니다!
