### PR TITLE
chore: PR Auto Assign 워크플로우 트리거 조건에 closed 이벤트 추가

### DIFF
--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -1,7 +1,7 @@
 name: 'PR Auto Assign'
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, closed, ready_for_review]
 
 jobs:
   assign:


### PR DESCRIPTION
## Issue

- close #18 

## ✨ 구현한 기능
merged-comment가 동작하려면 트리거 조건에 PR closed 이벤트가 있어야해서 추가했습니다!

- [x] PR Auto Assign 워크플로우 트리거 조건에 closed 이벤트 추가
