### PR TITLE
DialogConfirm 컴포넌트 구현

### DIFF
--- a/Frontend/.storybook/preview.tsx
+++ b/Frontend/.storybook/preview.tsx
@@ -6,6 +6,7 @@ import { QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-qu
 import { initialize, mswLoader } from 'msw-storybook-addon';
 import { withRouter } from 'storybook-addon-remix-react-router';
 
+import { DialogConfirmContextProvider } from '../src/components/@common';
 import { handlers } from '../src/mocks/handlers';
 import GlobalStyle from '../src/styles/GlobalStyle';
 import theme from '../src/styles/theme';
@@ -49,7 +50,9 @@ const preview: Preview = {
       <QueryClientProvider client={queryClient}>
         <ThemeProvider theme={theme}>
           <GlobalStyle />
-          <Story />
+          <DialogConfirmContextProvider>
+            <Story />
+          </DialogConfirmContextProvider>
         </ThemeProvider>
       </QueryClientProvider>
     ),

--- a/Frontend/src/App.tsx
+++ b/Frontend/src/App.tsx
@@ -1,13 +1,15 @@
 import { Outlet } from 'react-router-dom';
 
-import { DesktopLayout, MobileLayout } from '@/components/@common';
+import { DesktopLayout, DialogConfirmContextProvider, MobileLayout } from '@/components/@common';
 
 export default function App() {
   return (
-    <DesktopLayout>
-      <MobileLayout>
-        <Outlet />
-      </MobileLayout>
-    </DesktopLayout>
+    <DialogConfirmContextProvider>
+      <DesktopLayout>
+        <MobileLayout>
+          <Outlet />
+        </MobileLayout>
+      </DesktopLayout>
+    </DialogConfirmContextProvider>
   );
 }

--- a/Frontend/src/components/@common/Chip/Chip.stories.tsx
+++ b/Frontend/src/components/@common/Chip/Chip.stories.tsx
@@ -12,8 +12,8 @@ const meta = {
     color: { control: 'color' },
     backgroundColor: { control: 'color' },
     disabled: { control: 'boolean' },
-    width: { control: 'number' },
-    height: { control: 'number' },
+    width: { control: 'text' },
+    height: { control: 'text' },
   },
   args: {
     children: 'Chip',

--- a/Frontend/src/components/@common/Chip/Chip.tsx
+++ b/Frontend/src/components/@common/Chip/Chip.tsx
@@ -10,13 +10,14 @@ type ChipVariant = 'standard' | 'outline' | 'rounded' | 'tag';
 type ChipSize = 'sm' | 'md' | 'lg';
 
 export interface ChipProps extends PropsWithChildren {
+  as: keyof JSX.IntrinsicElements;
   variant: ChipVariant;
   size: ChipSize;
   color: CSSProperties['color'];
   backgroundColor: CSSProperties['backgroundColor'];
   disabled: boolean;
-  width: number;
-  height: number;
+  width: CSSProperties['width'];
+  height: CSSProperties['height'];
 }
 
 function Chip(chipProps: Partial<ChipProps>) {
@@ -135,8 +136,8 @@ const Wrapper = styled.div<Partial<ChipProps>>`
   ${({ variant, color, backgroundColor, disabled }) =>
     chipVariantStyles[variant ?? 'standard']({ color, backgroundColor, disabled })};
 
-  ${({ width }) => width && `width: ${width}rem`};
-  ${({ height }) => height && `height: ${height}rem`};
+  ${({ width }) => width && `width: ${width}`};
+  ${({ height }) => height && `height: ${height}`};
 `;
 
 const TextBox = styled.p`

--- a/Frontend/src/components/@common/ChipButton/ChipButton.tsx
+++ b/Frontend/src/components/@common/ChipButton/ChipButton.tsx
@@ -7,23 +7,23 @@ interface ChipButtonProps
     Partial<ChipProps> {}
 
 function ChipButton(chipButtonProps: ChipButtonProps) {
-  const { variant, size, color, backgroundColor, width, height, children, ...restProps } =
+  const { variant, size, color, backgroundColor, width, height, children, disabled, ...restProps } =
     chipButtonProps;
 
   return (
-    <button {...restProps}>
-      <Chip
-        variant={variant}
-        size={size}
-        color={color}
-        backgroundColor={backgroundColor}
-        disabled={restProps.disabled}
-        width={width}
-        height={height}
-      >
-        {children}
-      </Chip>
-    </button>
+    <Chip
+      as='button'
+      variant={variant}
+      size={size}
+      color={color}
+      backgroundColor={backgroundColor}
+      disabled={disabled}
+      width={width}
+      height={height}
+      {...restProps}
+    >
+      {children}
+    </Chip>
   );
 }
 

--- a/Frontend/src/components/@common/Dialog/Dialog.tsx
+++ b/Frontend/src/components/@common/Dialog/Dialog.tsx
@@ -75,7 +75,7 @@ function Content(contentProps: ContentProps) {
 
   return (
     <Wrapper ref={dialogRef} onClick={handleBackdropClick} location={location} {...restProps}>
-      {children}
+      <BoxForMobile>{children}</BoxForMobile>
     </Wrapper>
   );
 }
@@ -146,6 +146,7 @@ const dialogLocationStyles: DialogLocationStyles = {
 const Wrapper = styled.dialog<{ location: DialogLocation }>`
   max-width: 100vw;
 
+  background-color: transparent;
   border-radius: 20px;
   border: none;
 
@@ -174,4 +175,19 @@ const Wrapper = styled.dialog<{ location: DialogLocation }>`
   }
 
   ${({ location }) => dialogLocationStyles[location ?? 'center']}
+`;
+
+const BoxForMobile = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  width: 100%;
+  height: 100%;
+  background-color: transparent;
+
+  @media screen and (min-width: 768px) {
+    width: 430px;
+    left: 55%;
+  }
 `;

--- a/Frontend/src/components/@common/DialogConfirm/DialogConfirm.stories.tsx
+++ b/Frontend/src/components/@common/DialogConfirm/DialogConfirm.stories.tsx
@@ -1,0 +1,45 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { useConfirm } from '@/hooks/@common';
+import theme from '@/styles/theme';
+
+import DialogConfirm from './DialogConfirm';
+
+const meta = {
+  title: '@common/DialogConfirm',
+  component: DialogConfirm,
+} satisfies Meta<typeof DialogConfirm>;
+
+export default meta;
+type Story = StoryObj<typeof DialogConfirm>;
+
+export const Basic: Story = {
+  args: {
+    children: (
+      <button
+        type='button'
+        style={{
+          borderRadius: '8px',
+          backgroundColor: theme.colors.primary,
+          padding: '0.8rem',
+          color: theme.textColors.default,
+          fontWeight: theme.fontWeights.semiBold,
+        }}
+      >
+        Click Me!
+      </button>
+    ),
+  },
+  render: ({ children }) => {
+    const { confirm } = useConfirm();
+
+    const someHandler = async () => {
+      const confirmed = await confirm({ message: '설문 정보를 수정하시겠습니까?' });
+
+      if (confirmed) console.log('설문조사 페이지로 이동합니다.');
+      else console.log('이 페이지를 나가지 않습니다.');
+    };
+
+    return <DialogConfirm onClick={someHandler}>{children}</DialogConfirm>;
+  },
+};

--- a/Frontend/src/components/@common/DialogConfirm/DialogConfirm.tsx
+++ b/Frontend/src/components/@common/DialogConfirm/DialogConfirm.tsx
@@ -1,0 +1,81 @@
+import { PropsWithChildren } from 'react';
+
+import styled from '@emotion/styled';
+
+import { ChipButton, Dialog } from '@/components/@common';
+import { useConfirm } from '@/hooks/@common';
+import theme from '@/styles/theme';
+
+interface DialogConfirmProps {
+  onClick?: VoidFunction;
+}
+
+function DialogConfirm(dialogConfirmProps: PropsWithChildren<DialogConfirmProps>) {
+  const { children, onClick } = dialogConfirmProps;
+  const { confirmItem } = useConfirm();
+
+  return (
+    <Dialog location={'center'}>
+      <Dialog.Trigger asChild onClick={onClick}>
+        {children}
+      </Dialog.Trigger>
+      <Dialog.Content>
+        <ContentContainer>
+          <ContentWrapper>{confirmItem.message}</ContentWrapper>
+          <ButtonContainer>
+            <Dialog.Close aria-label='취소' asChild onClick={confirmItem.buttons.cancel.click}>
+              <ChipButton type='button' variant='outline' size='lg' width='100%'>
+                {confirmItem.buttons.cancel.text}
+              </ChipButton>
+            </Dialog.Close>
+            <Dialog.Close aria-label='확인' asChild onClick={confirmItem.buttons.ok.click}>
+              <ChipButton type='button' size='lg' width='100%'>
+                {confirmItem.buttons.ok.text}
+              </ChipButton>
+            </Dialog.Close>
+          </ButtonContainer>
+        </ContentContainer>
+      </Dialog.Content>
+    </Dialog>
+  );
+}
+
+export default DialogConfirm;
+
+const ContentContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  width: 90vw;
+  padding: 2.4rem;
+
+  background-color: ${theme.backgroundColors.normal};
+  border-radius: 20px;
+
+  @media screen and (min-width: 768px) {
+    width: calc(430px * 0.9);
+  }
+`;
+
+const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+
+  width: 100%;
+  height: 100%;
+  padding: 4.6rem 0;
+
+  text-align: center;
+  font-size: ${theme.fontSizes.md};
+  font-weight: ${theme.fontWeights.semiBold};
+  color: ${theme.textColors.white};
+`;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  gap: 0.8rem;
+
+  width: 100%;
+`;

--- a/Frontend/src/components/@common/DialogConfirm/DialogConfirmContext.tsx
+++ b/Frontend/src/components/@common/DialogConfirm/DialogConfirmContext.tsx
@@ -1,0 +1,67 @@
+import { Dispatch, PropsWithChildren, createContext, useMemo, useState } from 'react';
+
+import { useContextInScope } from '@/hooks/@common';
+
+interface ConfirmItem {
+  message: string;
+  buttons: {
+    ok: {
+      text: string;
+      click: VoidFunction;
+    };
+    cancel: {
+      text: string;
+      click: VoidFunction;
+    };
+  };
+}
+
+const INITIAL_CONFIRM_ITEM: ConfirmItem = {
+  message: '',
+  buttons: {
+    ok: {
+      text: '확인',
+      click: () => {},
+    },
+    cancel: {
+      text: '취소',
+      click: () => {},
+    },
+  },
+};
+
+interface DialogConfirmContext {
+  inScope: boolean;
+  confirmItem: ConfirmItem;
+  setConfirmItem: Dispatch<React.SetStateAction<ConfirmItem>>;
+}
+
+export const DialogConfirmContext = createContext<DialogConfirmContext>({
+  inScope: false,
+  confirmItem: INITIAL_CONFIRM_ITEM,
+  setConfirmItem: () => {},
+});
+
+const DIALOG_CONFIRM_NAME = 'Confirm';
+DialogConfirmContext.displayName = DIALOG_CONFIRM_NAME;
+
+export const useConfirmContext = () => useContextInScope(DialogConfirmContext);
+
+const DialogConfirmContextProvider = ({ children }: PropsWithChildren) => {
+  const [confirmItem, setConfirmItem] = useState<ConfirmItem>(INITIAL_CONFIRM_ITEM);
+
+  const memoizedValue = useMemo(
+    () => ({
+      inScope: true,
+      confirmItem,
+      setConfirmItem,
+    }),
+    [confirmItem],
+  );
+
+  return (
+    <DialogConfirmContext.Provider value={memoizedValue}>{children}</DialogConfirmContext.Provider>
+  );
+};
+
+export default DialogConfirmContextProvider;

--- a/Frontend/src/components/@common/index.ts
+++ b/Frontend/src/components/@common/index.ts
@@ -2,6 +2,8 @@ export { default as Chip } from './Chip/Chip';
 export { default as ChipButton } from './ChipButton/ChipButton';
 export { default as DesktopLayout } from './DesktopLayout/DesktopLayout';
 export { default as Dialog } from './Dialog/Dialog';
+export { default as DialogConfirm } from './DialogConfirm/DialogConfirm';
+export { default as DialogConfirmContextProvider } from './DialogConfirm/DialogConfirmContext';
 export { default as IndieroHeader } from './IndieroHeader/IndieroHeader';
 export { default as MobileLayout } from './MobileLayout/MobileLayout';
 export { default as NavigableHeader } from './NavigableHeader/NavigableHeader';

--- a/Frontend/src/hooks/@common/index.ts
+++ b/Frontend/src/hooks/@common/index.ts
@@ -1,2 +1,3 @@
+export { default as useConfirm } from './useConfirm';
 export { default as useContextInScope } from './useContextInScope';
 export { default as useEasyNavigate } from './useEasyNavigate';

--- a/Frontend/src/hooks/@common/useConfirm.ts
+++ b/Frontend/src/hooks/@common/useConfirm.ts
@@ -1,0 +1,39 @@
+import { useConfirmContext } from '@/components/@common/DialogConfirm/DialogConfirmContext';
+
+interface ConfirmProps {
+  message: string;
+  buttonLabel?: {
+    ok: string;
+    cancel: string;
+  };
+}
+
+const useConfirm = () => {
+  const { confirmItem, setConfirmItem } = useConfirmContext();
+
+  const confirm = (confirmProps: ConfirmProps) => {
+    const { message, buttonLabel = { ok: '확인', cancel: '취소' } } = confirmProps;
+
+    const confirmPromise = new Promise((resolve, reject) => {
+      setConfirmItem({
+        message,
+        buttons: {
+          ok: {
+            text: buttonLabel.ok,
+            click: () => resolve(true),
+          },
+          cancel: {
+            text: buttonLabel.cancel,
+            click: () => reject(false),
+          },
+        },
+      });
+    });
+
+    return confirmPromise.then(() => true).catch(() => false);
+  };
+
+  return { confirm, confirmItem };
+};
+
+export default useConfirm;


### PR DESCRIPTION
## Issue

- close #45

## ✨ 구현한 기능
![DialogConfirm_capture](https://github.com/INDIE-RO/INDIE-RO/assets/24777828/fcc9989f-98ab-47de-ab42-c8f8603aabf1)


Dialog컴포넌트를 활용하여 DialogConfirm 컴포넌트를 구현하였습니다.

### 사용방법
```tsx
function Homepage() {
  const { confirm } = useConfirm();
  const navigate = useNavigate();

  const someHandler = async () => {
    const confirmed = await confirm({ message: '설문 정보를 수정하시겠습니까?' }); // 컨펌창에 띄울 메시지를 입력값으로 설정

    if (confirmed) navigate(PATH.POLICY_LIST);
    else console.log('이 페이지를 나가지 않습니다.');
  };

  return (
    <section css={Container}>
      Homepage
      <DialogConfirm onClick={someHandler}>
        <button type='button'>컨펌창 띄우기</button> // 컨펌창을 트리거하는 버튼
      </DialogConfirm>
    </section>
  );
}
```

### useConfirm
```tsx
const useConfirm = () => {
  const { confirmItem, setConfirmItem } = useConfirmContext(); // confirmItem을 전역상태로 관리

  const confirm = (confirmProps: ConfirmProps) => {
    const { message, buttonLabel = { ok: '확인', cancel: '취소' } } = confirmProps; // 버튼 라벨에 기본값 할당

    const confirmPromise = new Promise((resolve, reject) => {
      setConfirmItem({
        message,
        buttons: {
          ok: {
            text: buttonLabel.ok,
            click: () => resolve(true), // ok버튼을 누를 경우 -> resolve를 호출하여 promise 상태를 fulfilled(이행)로 변경
          },
          cancel: {
            text: buttonLabel.cancel,
            click: () => reject(false), // cancel버튼을 누를 경우 -> resolve를 호출하여 promise 상태를 rejected(실패)로 변경
          },
        },
      });
    });

    return confirmPromise.then(() => true).catch(() => false); // ok인 경우 true, cancel인 경우 false 반환
  };

  return { confirm, confirmItem };
};
```

## 🎸 기타

- 데스크톱 뷰에서 Dialog를 center로 띄웠는데도 모바일레이아웃 center에 오지 않는 문제가 있어서 Dialog 컴포넌트 CSS도 수정했습니다!
