### PR TITLE
feat: SearchBar 구현

### DIFF
--- a/Frontend/.storybook/preview-body.html
+++ b/Frontend/.storybook/preview-body.html
@@ -56,7 +56,6 @@
     </symbol>
     <symbol id="search" viewBox="0 0 16 16">
       <path
-        stroke="#fff"
         strokeLinecap="round"
         strokeLinejoin="round"
         d="M6.857 13.143a6.286 6.286 0 1 0 0-12.572 6.286 6.286 0 0 0 0 12.572zm8.572 2.286l-4-4"

--- a/Frontend/.storybook/preview-body.html
+++ b/Frontend/.storybook/preview-body.html
@@ -54,5 +54,13 @@
         clipRule="evenodd"
       />
     </symbol>
+    <symbol id="search" viewBox="0 0 16 16">
+      <path
+        stroke="#fff"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M6.857 13.143a6.286 6.286 0 1 0 0-12.572 6.286 6.286 0 0 0 0 12.572zm8.572 2.286l-4-4"
+      />
+    </symbol>
   </svg>
 </div>

--- a/Frontend/src/components/@common/SearchBar/SearchBar.stories.tsx
+++ b/Frontend/src/components/@common/SearchBar/SearchBar.stories.tsx
@@ -1,0 +1,19 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+
+import SearchBar from './SearchBar';
+
+const meta = {
+  title: '@common/SearchBar',
+  component: SearchBar,
+} satisfies Meta<typeof SearchBar>;
+
+export default meta;
+type Story = StoryObj<typeof SearchBar>;
+
+export const Basic: Story = {
+  args: {
+    updateQuery: fn(),
+    onClickSearch: fn(),
+  },
+};

--- a/Frontend/src/components/@common/SearchBar/SearchBar.tsx
+++ b/Frontend/src/components/@common/SearchBar/SearchBar.tsx
@@ -1,0 +1,85 @@
+import { ChangeEvent, ComponentPropsWithoutRef, FormEvent } from 'react';
+
+import styled from '@emotion/styled';
+
+import { SvgIcon } from '@/components/@common';
+import theme from '@/styles/theme';
+
+interface SearchBarProps extends ComponentPropsWithoutRef<'input'> {
+  updateQuery: (event: ChangeEvent<HTMLInputElement>) => void;
+  onClickSearch?: VoidFunction;
+}
+
+function SearchBar(searchBarProps: SearchBarProps) {
+  const {
+    updateQuery,
+    onClickSearch,
+    placeholder = '원하는 키워드를 입력하세요',
+    maxLength = 255,
+    ...restProps
+  } = searchBarProps;
+
+  const onClick = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (onClickSearch) onClickSearch();
+  };
+
+  return (
+    <Wrapper onClick={onClick}>
+      <Input
+        placeholder={placeholder}
+        maxLength={maxLength}
+        {...restProps}
+        type='search'
+        inputMode='search'
+        onChange={updateQuery}
+      />
+      <Button aria-label='검색'>
+        <SvgIcon variant='search' stroke={theme.textColors.light} />
+      </Button>
+    </Wrapper>
+  );
+}
+
+export default SearchBar;
+
+const Wrapper = styled.form`
+  display: flex;
+
+  width: 100%;
+  height: 4.6rem;
+  padding: 1.1rem 1.6rem;
+  border-radius: 20px;
+
+  background-color: ${({ theme }) => theme.backgroundColors.light};
+`;
+
+const Button = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Input = styled.input`
+  width: 100%;
+  height: 100%;
+  margin-right: 0.8rem;
+
+  font-size: ${({ theme }) => theme.fontSizes.md};
+  font-weight: ${({ theme }) => theme.fontWeights.medium};
+  color: ${({ theme }) => theme.textColors.default};
+  line-height: 2rem;
+
+  outline: none;
+
+  &::placeholder {
+    color: ${({ theme }) => theme.textColors.light};
+  }
+
+  &::-webkit-search-decoration,
+  &::-webkit-search-cancel-button,
+  &::-webkit-search-results-button,
+  &::-webkit-search-results-decoration {
+    display: none;
+  }
+`;

--- a/Frontend/src/components/@common/SearchBar/SearchBar.tsx
+++ b/Frontend/src/components/@common/SearchBar/SearchBar.tsx
@@ -27,12 +27,12 @@ function SearchBar(searchBarProps: SearchBarProps) {
   return (
     <Wrapper onClick={onClick}>
       <Input
-        placeholder={placeholder}
-        maxLength={maxLength}
-        {...restProps}
         type='search'
         inputMode='search'
+        placeholder={placeholder}
+        maxLength={maxLength}
         onChange={updateQuery}
+        {...restProps}
       />
       <Button aria-label='검색'>
         <SvgIcon variant='search' stroke={theme.textColors.light} />

--- a/Frontend/src/components/@common/Svg/SvgIcon.tsx
+++ b/Frontend/src/components/@common/Svg/SvgIcon.tsx
@@ -11,6 +11,7 @@ export const SVG_ICON_VARIANTS = [
   'arrowUp',
   'check',
   'close',
+  'search',
 ] as const;
 export type SvgIconVariant = (typeof SVG_ICON_VARIANTS)[number];
 

--- a/Frontend/src/components/@common/Svg/SvgSprite.tsx
+++ b/Frontend/src/components/@common/Svg/SvgSprite.tsx
@@ -52,7 +52,6 @@ function SvgSprite() {
       </symbol>
       <symbol id='search' viewBox='0 0 16 16'>
         <path
-          stroke='#fff'
           strokeLinecap='round'
           strokeLinejoin='round'
           d='M6.857 13.143a6.286 6.286 0 1 0 0-12.572 6.286 6.286 0 0 0 0 12.572zm8.572 2.286l-4-4'

--- a/Frontend/src/components/@common/Svg/SvgSprite.tsx
+++ b/Frontend/src/components/@common/Svg/SvgSprite.tsx
@@ -50,6 +50,14 @@ function SvgSprite() {
           clipRule='evenodd'
         />
       </symbol>
+      <symbol id='search' viewBox='0 0 16 16'>
+        <path
+          stroke='#fff'
+          strokeLinecap='round'
+          strokeLinejoin='round'
+          d='M6.857 13.143a6.286 6.286 0 1 0 0-12.572 6.286 6.286 0 0 0 0 12.572zm8.572 2.286l-4-4'
+        />
+      </symbol>
     </svg>
   );
 }

--- a/Frontend/src/components/@common/index.ts
+++ b/Frontend/src/components/@common/index.ts
@@ -8,6 +8,7 @@ export { default as IndieroHeader } from './IndieroHeader/IndieroHeader';
 export { default as MobileLayout } from './MobileLayout/MobileLayout';
 export { default as NavigableHeader } from './NavigableHeader/NavigableHeader';
 export { default as NavigationBar } from './NavigationBar/NavigationBar';
+export { default as SearchBar } from './SearchBar/SearchBar';
 export { default as SvgIcon } from './Svg/SvgIcon';
 export { default as SvgSprite } from './Svg/SvgSprite';
 export { default as Toast } from './Toast/Toast';

--- a/Frontend/src/hooks/@common/index.ts
+++ b/Frontend/src/hooks/@common/index.ts
@@ -1,3 +1,4 @@
 export { default as useConfirm } from './useConfirm';
 export { default as useContextInScope } from './useContextInScope';
+export { default as useDebounce } from './useDebounce';
 export { default as useEasyNavigate } from './useEasyNavigate';

--- a/Frontend/src/hooks/@common/useDebounce.ts
+++ b/Frontend/src/hooks/@common/useDebounce.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+const useDebounce = <T>(value: T, delay: number = 500): T => {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timerId = setTimeout(() => setDebouncedValue(value), delay);
+
+    return () => {
+      clearTimeout(timerId);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+};
+
+export default useDebounce;


### PR DESCRIPTION
## Issue

- close #71 

## ✨ 구현한 기능
<img width="1012" alt="image" src="https://github.com/INDIE-RO/INDIE-RO/assets/24777828/314a3ca9-9ee7-4d99-bbbe-685f42418c2c">

- [x] 돋보기 아이콘 SVG 등록
- [x] SearchBar 구현

### SearchBar
- `input type = 'search'`를 사용하여 `ESC`키를 눌렀을 때 입력한 내용이 삭제되도록 했습니다.
- x버튼도 생성되는데 이건 미관상 예쁘지도 않고 다른 검색 사이트를 봤을 때도 남겨둔 곳이 없는 것 같아 저도 CSS로 없앴어요!
- Wrapper는 `form` 태그를 사용해서 `Enter`키를 눌렀을 때 이벤트가 실행되도록 했습니당

### Props
- `updateQuery`:  검색 키워드 상태를 업데이트하는 함수입니다.
- `onClickSearch`: 돋보기 버튼 클릭 또는 `Enter`키를 눌렀을 때 실행되는 함수입니다.

## 📢 논의하고 싶은 내용

- 연관검색어 기능 추가를 고려하여 `useDebounce` 훅도 구현했습니다.
- `useDebounce`를 사용하여 특정 `delay` 시간 이후 검색 키워드 `state`를 업데이트 하는 방식으로 사용하면 될 것 같아요~ 

