### PR TITLE
fix: dialog height 100%로 설정하여 모바일 디바이스에서 보이지 않는 문제 해결

### DIFF
--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "scripts": {
     "start": "webpack serve --mode=development & open 'http://localhost:3000'",
+    "build": "webpack --mode=production",
     "test": "echo \"Error: no test specified\" && exit 1",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"

--- a/Frontend/src/components/@common/Dialog/Dialog.tsx
+++ b/Frontend/src/components/@common/Dialog/Dialog.tsx
@@ -146,6 +146,7 @@ const dialogLocationStyles: DialogLocationStyles = {
 
 const Wrapper = styled.dialog<{ location: DialogLocation }>`
   max-width: 100vw;
+  height: 100%;
 
   background-color: transparent;
   border-radius: 20px;


### PR DESCRIPTION
## Issue

- close #124 

### 문제
<img width="375" alt="스크린샷 2024-06-18 오후 11 01 33" src="https://github.com/INDIE-RO/INDIE-RO/assets/24777828/a9098463-9f30-4256-8f82-007798bf563a">

모바일 디바이스 chrome, safari 브라우저에서 dialog 태그로 만들어진 컴포넌트가 보이지 않음

### 원인
<img width="700" alt="스크린샷 2024-06-18 오후 11 01 33" src="https://github.com/INDIE-RO/INDIE-RO/assets/24777828/fa6fd845-042e-407b-ad9d-f3798846fe37">

dialog 태그 height: fit-content 때문에 모바일 브라우저에서 높이 0으로 설정됨

### 해결방안
<img width="700" alt="스크린샷 2024-06-18 오후 11 03 09" src="https://github.com/INDIE-RO/INDIE-RO/assets/24777828/546a78cc-4030-4a5a-97da-c1dd4846e0a7">

dialog 태그 height: 100로 수정

### 예상 결과화면
<img width="375" alt="스크린샷 2024-06-18 오후 11 01 33" src="https://github.com/INDIE-RO/INDIE-RO/assets/24777828/5ca50402-38c7-4597-b4c0-93efe740522e">

