### PR TITLE
feat: 모바일 웹 dialog 관련 스타일 수정

### DIFF
--- a/Frontend/src/components/@common/Dialog/Dialog.tsx
+++ b/Frontend/src/components/@common/Dialog/Dialog.tsx
@@ -160,6 +160,10 @@ const Wrapper = styled.dialog<{ location: DialogLocation }>`
   }
 
   ${({ location }) => dialogLocationStyles[location ?? 'center']}
+
+  @media screen and (min-width: 768px) {
+    height: fit-content;
+  }
 `;
 
 const BoxForMobile = styled.div`

--- a/Frontend/src/components/Policy/PolicyFilterBottomSheet/PolicyFilterBottomSheet.tsx
+++ b/Frontend/src/components/Policy/PolicyFilterBottomSheet/PolicyFilterBottomSheet.tsx
@@ -12,6 +12,8 @@ interface PolicyFilterBottomSheetProps {
   categoryId: number;
 }
 
+const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+
 function PolicyFilterBottomSheet({ categoryId }: PolicyFilterBottomSheetProps) {
   const {
     ageMeta,
@@ -57,6 +59,7 @@ function PolicyFilterBottomSheet({ categoryId }: PolicyFilterBottomSheetProps) {
             </CloseButton>
           </Dialog.Close>
           <FilterListContainer>
+            {isMobile && <div style={{ minHeight: '16px' }} />}
             <PolicyFilterList
               metaDataList={openingStatusMeta}
               labelText='모집현황'
@@ -84,6 +87,7 @@ function PolicyFilterBottomSheet({ categoryId }: PolicyFilterBottomSheetProps) {
           <Dialog.Close asChild onClick={() => onSubmit}>
             <ChipButton width='100%'>필터적용</ChipButton>
           </Dialog.Close>
+          {isMobile && <div style={{ minHeight: '100px' }} />}
         </ContentWrapper>
       </Dialog.Content>
     </Dialog>

--- a/Frontend/src/components/Policy/PolicyFilterBottomSheet/PolicyFilterBottomSheet.tsx
+++ b/Frontend/src/components/Policy/PolicyFilterBottomSheet/PolicyFilterBottomSheet.tsx
@@ -113,6 +113,7 @@ const ContentWrapper = styled.form`
   padding: 2.8rem;
 
   background-color: ${theme.backgroundColors.normal};
+  overflow-y: auto;
 `;
 
 const CloseButton = styled.button`

--- a/Frontend/src/styles/GlobalStyle.tsx
+++ b/Frontend/src/styles/GlobalStyle.tsx
@@ -83,6 +83,10 @@ const baseStyle = css`
     cursor: pointer;
   }
 
+  button:focus {
+    outline: none;
+  }
+
   button:disabled {
     cursor: not-allowed;
   }

--- a/Frontend/src/styles/GlobalStyle.tsx
+++ b/Frontend/src/styles/GlobalStyle.tsx
@@ -17,6 +17,11 @@ const baseStyle = css`
   * {
     margin: 0;
     padding: 0;
+
+    &:has(dialog[open]) {
+      /* dialog를 포함하는 요소 선택 - dialog open 시 배경 스크롤 막기 */
+      overflow: hidden;
+    }
   }
 
   *,


### PR DESCRIPTION
## Issue

- close #126 

## ✨ 구현한 기능

모바일 웹인 경우 dialog에서 아래와 같은 문제가 있어 스타일을 수정했습니다.
- 바텀시트 내부 스크롤이 안됨
- 모바일웹 하단 네비게이션바에 가려 필터적용 버튼 안보임

모바일로 확인하려고 10번 넘게 배포하면서 겨우 해결했네요..🫠
[인디로 배포 링크](https://d3jnkfd7908mul.cloudfront.net/)에는 반영해놓은 상태입니다.

- [x] dialog 데스크톱뷰일 경우 height: fit-content로 수정
- [x] 글로벌 스타일에 open된 dialog를 포함하는 요소 스크롤 막기
- [x] 필터 바텀시트 내부 form 태그에 overflow-y: auto 속성 주기
- [x] 모바일 웹인 경우 필터 바텀시트 내부 form 태그 안 필터적용 버튼 밑에 100px 띄우기
- [x] 모바일 웹인 경우 필터 바텀시트 내부 form 태그 안 필터 리스트 컨테이너 위에 16px 띄우기

### 🎸 기타
- 모바일 웹인 경우 필터 바텀시트 내부 form 태그 안 필터적용 버튼 밑에 100px 띄우기
  - 100px 띄울 때 height로 하면 높이가 0이 되어서 적용 안됨, 이유는 모르겠지만 minHeight를 주면 적용됨!
```tsx
  {isMobile && <div style={{ minHeight: '20px' }} />}
```

- dialog 관련 스타일 수정하면서 버튼 포커스 되는 경우 아웃라인이 안 보이도록 버튼 글로벌 스타일도 수정했습니다.

참고
- [모바일 웹인지 확인하는 법](https://velog.io/@crg1050/%ED%8F%AC%ED%8A%B8%ED%8F%B4%EB%A6%AC%EC%98%A4-%EB%AA%A8%EB%B0%94%EC%9D%BC-%ED%99%98%EA%B2%BD%EC%97%90%EC%84%9C-100vh-%EC%9D%B4%EC%8A%88)
