### PR TITLE
feat: 정책 상세정보 개행문자 적용 및 맞춤정보 네비게이터 오류 해결

### DIFF
--- a/Frontend/src/components/@common/NavigationBar/NavigationBar.tsx
+++ b/Frontend/src/components/@common/NavigationBar/NavigationBar.tsx
@@ -4,6 +4,7 @@ import { NavLink, useNavigate } from 'react-router-dom';
 import styled from '@emotion/styled';
 
 import { DialogConfirm, SvgIcon } from '@/components/@common';
+import { useCustomInfo } from '@/components/Policy/CustomInfo/CustomInfo.hook';
 import { NAVIGATION_MENU, PATH } from '@/constants/path';
 import { useConfirm } from '@/hooks/@common';
 import theme from '@/styles/theme';
@@ -11,6 +12,7 @@ import theme from '@/styles/theme';
 function NavigationBar() {
   const { confirm } = useConfirm();
   const navigate = useNavigate();
+  const { getCustomInfoQueryString } = useCustomInfo();
 
   const [isActive, setIsActive] = useState(false);
 
@@ -44,7 +46,7 @@ function NavigationBar() {
                 </SurveyLinkWrapper>
               </DialogConfirm>
             ) : (
-              <Link to={path}>
+              <Link to={variant === 'user' ? path + getCustomInfoQueryString() : path}>
                 {({ isActive }) => (
                   <>
                     <SvgIcon

--- a/Frontend/src/components/Policy/CustomInfo/CustomInfo.hook.ts
+++ b/Frontend/src/components/Policy/CustomInfo/CustomInfo.hook.ts
@@ -9,7 +9,7 @@ import {
   useSurveyRegionMetaQuery,
 } from '@/pages/SurveyPage/Survey.query';
 import { indieroLocalStorage } from '@/utils/localStorage';
-import { generateQueryString } from '@/utils/route';
+import { generateQueryString, replaceQueryString } from '@/utils/route';
 
 export const useCustomInfo = () => {
   const { ageMeta } = useSurveyAgeMetaQuery();
@@ -57,13 +57,18 @@ export const useCustomInfo = () => {
     navigate(PATH.SURVEY);
   };
 
+  const getCustomInfoQueryString = () => {
+    const exclude = ['sortBy'];
+    return replaceQueryString(generateQueryString(getCustomInfoQueryParams()), exclude);
+  };
+
   const navigateCustomInfo = () => {
-    updateQueryParams(generateQueryString(getCustomInfoQueryParams()), { path: PATH.CUSTOM_INFO });
+    updateQueryParams(getCustomInfoQueryString());
   };
 
   useLayoutEffect(() => {
-    navigateCustomInfo();
+    if (location.pathname === PATH.CUSTOM_INFO) navigateCustomInfo();
   }, [surveyResult?.age, surveyResult?.category.join(), surveyResult?.region.join()]);
 
-  return { surveyResult, goSurveyPage };
+  return { surveyResult, goSurveyPage, getCustomInfoQueryString };
 };

--- a/Frontend/src/components/Policy/PolicyDetailContent/PolicyDetailContent.tsx
+++ b/Frontend/src/components/Policy/PolicyDetailContent/PolicyDetailContent.tsx
@@ -1,5 +1,7 @@
 import { Fragment } from 'react';
 
+import styled from '@emotion/styled';
+
 import { Chip } from '@/components/@common';
 import { Description, OtherInfo, Qualification } from '@/pages/PolicyDetailPage/PolicyDetail.type';
 import theme from '@/styles/theme';
@@ -23,7 +25,7 @@ function PolicyDetailContent({ titles, contents }: PolicyDetailContentProps) {
             {titles[idx]}
           </Chip>
           <div style={{ height: '10px' }} />
-          <p>{value}</p>
+          <PreformattedText>{value}</PreformattedText>
           <div style={{ height: '40px' }} />
         </Fragment>
       ))}
@@ -32,3 +34,7 @@ function PolicyDetailContent({ titles, contents }: PolicyDetailContentProps) {
 }
 
 export default PolicyDetailContent;
+
+const PreformattedText = styled.pre`
+  white-space: pre-wrap;
+`;


### PR DESCRIPTION
## Issue

- close #156 

## ✨ 구현한 기능

- [x] 정책 상세정보 개행문자 적용되도록 pre태그로 변경
- [x] 맞춤정보 2번 클릭 시 쿼리 정책정보 없음 이미지 뜨는 문제 해결(원인: 네비게이션바에서 맞춤정보 클릭 시 쿼리파라미터 초기화됨)

### before
<img width="369" alt="image" src="https://github.com/INDIE-RO/INDIE-RO/assets/24777828/18a7c452-e943-4f74-9fd4-6be9e6979aa1">

### after
<img width="369" alt="image" src="https://github.com/INDIE-RO/INDIE-RO/assets/24777828/14650389-ca1f-40d7-8121-ce01f8112385">
