### PR TITLE
에러바운더리 추가 및 에러페이지 생성

### DIFF
--- a/Frontend/src/App.tsx
+++ b/Frontend/src/App.tsx
@@ -4,12 +4,13 @@ import { Outlet, useNavigate } from 'react-router-dom';
 import {
   DesktopLayout,
   DialogConfirmContextProvider,
+  ErrorBoundary,
   MobileLayout,
   ToastContextProvider,
 } from '@/components/@common';
 
 import { PATH } from './constants/path';
-import { LoadingPage } from './pages';
+import { ErrorPage, LoadingPage } from './pages';
 import { indieroLocalStorage } from './utils/localStorage';
 
 export default function App() {
@@ -27,11 +28,13 @@ export default function App() {
     <ToastContextProvider>
       <DialogConfirmContextProvider>
         <DesktopLayout>
-          <Suspense fallback={<LoadingPage />}>
-            <MobileLayout>
-              <Outlet />
-            </MobileLayout>
-          </Suspense>
+          <ErrorBoundary fallback={ErrorPage}>
+            <Suspense fallback={<LoadingPage />}>
+              <MobileLayout>
+                <Outlet />
+              </MobileLayout>
+            </Suspense>
+          </ErrorBoundary>
         </DesktopLayout>
       </DialogConfirmContextProvider>
     </ToastContextProvider>

--- a/Frontend/src/components/@common/ErrorBoundary/ErrorBoundary.tsx
+++ b/Frontend/src/components/@common/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,39 @@
+import { Component, ElementType, ErrorInfo, PropsWithChildren } from 'react';
+
+interface Props extends PropsWithChildren {
+  fallback: ElementType;
+}
+
+interface State {
+  hasError: boolean;
+  info: Error | null;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, info: null };
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { hasError: true, info: error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error(error);
+    console.error(errorInfo);
+  }
+
+  render() {
+    const { hasError, info } = this.state;
+    const { children } = this.props;
+
+    if (hasError) {
+      return <this.props.fallback error={info} />;
+    }
+
+    return children;
+  }
+}
+
+export default ErrorBoundary;

--- a/Frontend/src/components/@common/index.ts
+++ b/Frontend/src/components/@common/index.ts
@@ -5,6 +5,7 @@ export { default as Dialog } from './Dialog/Dialog';
 export { default as DialogConfirm } from './DialogConfirm/DialogConfirm';
 export { default as DialogConfirmContextProvider } from './DialogConfirm/DialogConfirmContext';
 export { default as Dropdown } from './Dropdown/Dropdown';
+export { default as ErrorBoundary } from './ErrorBoundary/ErrorBoundary';
 export { default as IndieroHeader } from './IndieroHeader/IndieroHeader';
 export { default as BasicLayout } from './Layout/BasicLayout';
 export { default as DesktopLayout } from './Layout/DesktopLayout';

--- a/Frontend/src/pages/ErrorPage.tsx
+++ b/Frontend/src/pages/ErrorPage.tsx
@@ -1,0 +1,56 @@
+import styled from '@emotion/styled';
+
+import NotFound from '@/assets/notFound.svg?url';
+import { useEasyNavigate } from '@/hooks/@common';
+import theme from '@/styles/theme';
+
+function ErrorPage(error?: Error) {
+  const { goHome } = useEasyNavigate();
+
+  const refresh = () => {
+    goHome();
+    window.location.reload();
+  };
+
+  return (
+    <Container>
+      <img src={NotFound} alt='' width={250} height={250} />
+      <div style={{ height: '40px' }} />
+      <h1>문제가 발생했어요!</h1>
+      <div style={{ height: '20px' }} />
+      {error?.message && <p>[ERROR]{error.message}</p>}
+      <pre>
+        {'\n인디로 팀이 해결 중이니 잠시 후 다시 시도해주세요!\n만일 동일한 문제가 계속된다면'}
+      </pre>
+      <a href='indiero2024@gmail.com'>indiero2024@gmail.com으로 연락해 주세요.</a>
+      <div style={{ height: '30px' }} />
+      <HomeButton type='button' onClick={refresh}>
+        홈으로 돌아가기
+      </HomeButton>
+    </Container>
+  );
+}
+
+export default ErrorPage;
+
+const Container = styled.section`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100%;
+  text-align: center;
+`;
+
+const HomeButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 124px;
+  height: 36px;
+  padding: 22px 80px;
+  border: 1px solid ${theme.colors.white};
+  border-radius: 20px;
+  white-space: nowrap;
+  color: ${theme.textColors.white};
+`;

--- a/Frontend/src/pages/index.ts
+++ b/Frontend/src/pages/index.ts
@@ -1,9 +1,10 @@
 export { default as CustomInfoPage } from './CustomInfoPage';
+export { default as ErrorPage } from './ErrorPage';
 export { default as Homepage } from './Homepage';
 export { default as IntroPage } from './IntroPage';
+export { default as LoadingPage } from './LoadingPage';
+export { default as NotFoundPage } from './NotFoundPage';
 export { default as PolicyDetailPage } from './PolicyDetailPage/PolicyDetailPage';
 export { default as PolicyListPage } from './PolicyListPage';
 export { default as PolicySearchPage } from './PolicySearchPage/PolicySearchPage';
 export { default as SurveyPage } from './SurveyPage/SurveyPage';
-export { default as NotFoundPage } from './NotFoundPage';
-export { default as LoadingPage } from './LoadingPage';


### PR DESCRIPTION
## Issue

- close #162 

![handle_error_capture](https://github.com/INDIE-RO/INDIE-RO/assets/24777828/c2cd571d-5a39-4225-b7d5-fe402aadeae6)


## ✨ 구현한 기능

- [x] 에러바운더리 적용
- [x] 에러페이지 추가

## 📢 논의하고 싶은 내용

토스트를 쿼리 에러 핸들링에 추가하고 싶었는데 쿼리 클라이언트는 토스프로바이더 외부에 있어서 설정할 수가 없었습니다 ㅠ
App컴포넌트에서 쿼리클라이언트의 쿼리캐시 옵션을 변경할 수 있나 찾아봤는데 defaultOptions는 변경이 가능한데 queryCache는 변경할 수 있는 메서드가 없더라고용.. 다음에 토스트를 만들 때에는 리액트에 의존하지 않도록 만들어야 사용이 쉽겠다는 생각을 했습니다.. ㅡ.,ㅡ!

```tsx
const queryClient = new QueryClient({
  defaultOptions: {
    queries: {
      retry: 0,
      staleTime: 1000 * 60 * 5 /** @TODO 논의 후 값 변경 필요 */,
      gcTime: 1000 * 60 * 5,
      throwOnError: true,
    },
  },
  queryCache: new QueryCache({
    onError: error => {
      alert(error.message); // 여기
    },
  }),
});
```

## 🎸 기타

- 특이 사항이 있으면 작성합니다.
