### PR TITLE
fix: 정책 쿼리 요청 시 직전에 봤던 정책 id로 요청하도록 설정

### DIFF
--- a/Frontend/src/components/Policy/RecommendedPolicy/RecommendedPolicy.api.ts
+++ b/Frontend/src/components/Policy/RecommendedPolicy/RecommendedPolicy.api.ts
@@ -2,18 +2,19 @@ import { indieroClient } from '@/apis/ClientApi';
 import { ERROR_MESSAGE } from '@/constants/error';
 import { API_PATH } from '@/constants/path';
 import { RecommendedPolicy } from '@/types/common';
-import { indieroLocalStorage } from '@/utils/localStorage';
 
 export interface GetRecommendedPolicyResponse {
   recommendedPolicies: RecommendedPolicy[];
 }
 
-const recentViewedPolicyId = indieroLocalStorage.getRecentViewedPolicyId();
+export interface GetRecommendedPolicyRequest {
+  id?: number;
+}
 
-export const getRecommendedPolicy = async () => {
+export const getRecommendedPolicy = async ({ id }: GetRecommendedPolicyRequest) => {
   try {
     const data = await indieroClient.get<GetRecommendedPolicyResponse>(API_PATH.RECOMMEND_POLICY, {
-      params: { id: recentViewedPolicyId },
+      params: { id },
     });
 
     if (!data) throw new Error('추천 정책을 불러오는 데 실패했습니다.');

--- a/Frontend/src/components/Policy/RecommendedPolicy/RecommendedPolicy.query.ts
+++ b/Frontend/src/components/Policy/RecommendedPolicy/RecommendedPolicy.query.ts
@@ -9,12 +9,10 @@ export const RECOMMEND_POLICY_QUERY_KEY = {
 } as const;
 
 export const useRecommendedPolicyQuery = () => {
-  const recentViewedPolicyId = indieroLocalStorage.getRecentViewedPolicyId() ?? 0;
+  const recentViewedPolicyId = indieroLocalStorage.getRecentViewedPolicyId() ?? undefined;
   const { data, ...restQuery } = useSuspenseQuery({
     queryKey: [RECOMMEND_POLICY_QUERY_KEY.RECOMMENDED_POLICY, recentViewedPolicyId],
-    queryFn: getRecommendedPolicy,
-    staleTime: 0,
-    gcTime: 0,
+    queryFn: () => getRecommendedPolicy({ id: recentViewedPolicyId }),
   });
 
   return {


### PR DESCRIPTION
## Issue

- close #178 

## ✨ 구현한 기능

- 정책 쿼리 요청 시 직전에 봤던 정책 id로 요청하도록 설정