### PR TITLE
fix: 정책 상세에서 url 존재하지 않는 경우 버튼 비활성화

### DIFF
--- a/Frontend/src/pages/PolicyDetailPage/PolicyDetailPage.tsx
+++ b/Frontend/src/pages/PolicyDetailPage/PolicyDetailPage.tsx
@@ -75,10 +75,10 @@ function PolicyDetailPage() {
         <ChipButton
           size='lg'
           width='100%'
-          disabled={!policyDetail.url}
+          disabled={policyDetail.url === '-'}
           onClick={() => window.open(policyDetail.url)}
         >
-          {policyDetail.url ? '살펴보러가기' : '링크 정보가 없어요 🥲'}
+          {policyDetail.url === '-' ? '링크 정보가 없어요 🥲' : '살펴보러가기'}
         </ChipButton>
       </ButtonWrapper>
     </Container>


### PR DESCRIPTION
## Issue

- close #181 

## ✨ 구현한 기능

정책 상세에서 url 존재하지 않는 경우 버튼 비활성화