### PR TITLE
fix: 기본 추천 정책 id 변경

### DIFF
--- a/Backend/Indiero/src/main/java/com/indiero/service/PolicyService.java
+++ b/Backend/Indiero/src/main/java/com/indiero/service/PolicyService.java
@@ -300,8 +300,8 @@ public class PolicyService {
 
     private List<RecommendationPolicyResponse> getDefaultRecommendations() {
         return List.of(
-                new RecommendationPolicyResponse(1814L, "2024년 자립준비청년(청년 유형) 전세임대"),
-                new RecommendationPolicyResponse(1823L, "자립준비청년 의료비 지원 사업")
+                new RecommendationPolicyResponse(1821L, "2024년 자립준비청년(청년 유형) 전세임대"),
+                new RecommendationPolicyResponse(1830L, "자립준비청년 의료비 지원 사업")
         );
     }
 


### PR DESCRIPTION
## Issue

- close #184 

## ✨ 구현한 기능

- 기본으로 내려주는 추천 정책 id 값을 변경했습니다.
```
1821 : 2024년 자립준비청년(청년 유형) 전세임대
1830 : 자립준비청년 의료비 지원 사업
```