### PR TITLE
chore: gh-pages 배포 워크플로우 추가

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -1,73 +1,73 @@
-name: Frontend Deploy
+# name: Frontend Deploy
 
-on:
-  push:
-    branches:
-      - develop
-      - main
-    paths:
-      - 'Frontend/**'
-      - .github/**
+# on:
+#   push:
+#     branches:
+#       - develop
+#       - main
+#     paths:
+#       - 'Frontend/**'
+#       - .github/**
 
-jobs:
-  build-and-deploy:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./Frontend
-    timeout-minutes: 10
+# jobs:
+#   build-and-deploy:
+#     runs-on: ubuntu-latest
+#     defaults:
+#       run:
+#         working-directory: ./Frontend
+#     timeout-minutes: 10
 
-    permissions:
-      checks: write
-      pull-requests: write
+#     permissions:
+#       checks: write
+#       pull-requests: write
 
-    steps:
-      - name: Repository 체크아웃
-        uses: actions/checkout@v3
+#     steps:
+#       - name: Repository 체크아웃
+#         uses: actions/checkout@v3
 
-      - name: Node 설정
-        uses: actions/setup-node@v3
-        with:
-          node-version: '20.11.1'
+#       - name: Node 설정
+#         uses: actions/setup-node@v3
+#         with:
+#           node-version: '20.11.1'
 
-      - name: pnpm 설치
-        uses: pnpm/action-setup@v3
-        with:
-          version: 9.1.3
+#       - name: pnpm 설치
+#         uses: pnpm/action-setup@v3
+#         with:
+#           version: 9.1.3
 
-      - name: node_modules 캐싱
-        id: cache
-        uses: actions/cache@v3
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-node-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
+#       - name: node_modules 캐싱
+#         id: cache
+#         uses: actions/cache@v3
+#         with:
+#           path: '**/node_modules'
+#           key: ${{ runner.os }}-node-${{ hashFiles('**/pnpm-lock.yaml') }}
+#           restore-keys: |
+#             ${{ runner.os }}-node-
 
-      - name: 의존성 설치
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: pnpm install --no-frozen-lockfile
+#       - name: 의존성 설치
+#         if: steps.cache.outputs.cache-hit != 'true'
+#         run: pnpm install --no-frozen-lockfile
 
-      - name: .env 파일 생성
-        run: |
-          echo "BASE_URL=${{ secrets.BASE_URL }}" >> .env
-          echo "GOOGLE_ANALYTICS_ID=${{ secrets.GOOGLE_ANALYTICS_ID }}" >> .env
+#       - name: .env 파일 생성
+#         run: |
+#           echo "BASE_URL=${{ secrets.BASE_URL }}" >> .env
+#           echo "GOOGLE_ANALYTICS_ID=${{ secrets.GOOGLE_ANALYTICS_ID }}" >> .env
 
-      - name: 클라이언트 빌드
-        run: pnpm build
+#       - name: 클라이언트 빌드
+#         run: pnpm build
 
-      - name: AWS CLI 설정
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ap-northeast-2
+#       - name: AWS CLI 설정
+#         uses: aws-actions/configure-aws-credentials@v1
+#         with:
+#           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#           aws-region: ap-northeast-2
 
-      - name: S3에 배포
-        run: aws s3 sync ./dist s3://indiero-bucket --delete
+#       - name: S3에 배포
+#         run: aws s3 sync ./dist s3://indiero-bucket --delete
 
-      - name: Cloudfront 무효화
-        run: |
-          aws cloudfront create-invalidation \
-            --distribution-id ${{ secrets.AWS_DISTRIBUTION_ID }} \
-            --paths "/*"
+#       - name: Cloudfront 무효화
+#         run: |
+#           aws cloudfront create-invalidation \
+#             --distribution-id ${{ secrets.AWS_DISTRIBUTION_ID }} \
+#             --paths "/*"

--- a/.github/workflows/frontend-pages-deploy.yml
+++ b/.github/workflows/frontend-pages-deploy.yml
@@ -1,0 +1,77 @@
+name: Frontend Pages Deploy
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+    paths:
+      - 'Frontend/**'
+      - .github/**
+
+  workflow_dispatch: # 수동 실행을 위한 설정
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./Frontend
+    permissions:
+      contents: write
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Use repository source
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20.11.1
+
+      - name: pnpm 설치
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9.1.3
+
+      - name: Cache dependencies
+        id: cache
+        uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-node-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Set PUBLIC_URL
+        run: |
+          PUBLIC_URL=$(echo $GITHUB_REPOSITORY | sed -r 's/^.+\/(.+)$/\/\1\//')
+          echo PUBLIC_URL=$PUBLIC_URL > .env
+
+      - name: Create .env
+        run: |
+          echo "BASE_URL=${{ secrets.BASE_URL }}" >> .env
+          echo "GOOGLE_ANALYTICS_ID=${{ secrets.GOOGLE_ANALYTICS_ID }}" >> .env
+
+      - name: Build App
+        run: |
+          pnpm build
+          cp ./dist/index.html ./dist/404.html
+
+      - name: Build Storybook
+        run: |
+          pnpm build:sb
+          mv ./storybook-static ./dist/storybook
+
+      - name: Deploy To 'gh-pages' Branch
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist

--- a/.github/workflows/frontend-pages-deploy.yml
+++ b/.github/workflows/frontend-pages-deploy.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           node-version: 20.11.1
 
-      - name: pnpm 설치
+      - name: Install pnpm
         uses: pnpm/action-setup@v3
         with:
           version: 9.1.3

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -6,7 +6,7 @@
     "start": "webpack serve --mode=development & open 'http://localhost:3000'",
     "build": "webpack --mode=production",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
+    "build:sb": "storybook build",
     "test": "playwright test --reporter=list",
     "test:headed": "playwright test --headed --reporter=list",
     "test:ui": "playwright test --ui",

--- a/Frontend/src/index.tsx
+++ b/Frontend/src/index.tsx
@@ -16,9 +16,9 @@ import theme from './styles/theme';
 ReactGA.initialize(process.env.GOOGLE_ANALYTICS_ID);
 
 const enableMocking = async () => {
-  if (process.env.NODE_ENV !== 'development') {
-    return;
-  }
+  // if (process.env.NODE_ENV !== 'development') {
+  //   return;
+  // }
 
   const { worker } = await import('./mocks/browser');
   return worker.start();
@@ -28,7 +28,7 @@ const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       retry: 0,
-      staleTime: 1000 * 60 * 5 /** @TODO 논의 후 값 변경 필요 */,
+      staleTime: 1000 * 60 * 5,
       gcTime: 1000 * 60 * 5,
       throwOnError: true,
     },
@@ -40,7 +40,6 @@ const queryClient = new QueryClient({
   }),
 });
 
-/** @TODO ErrorBoundary 추가 필요 */
 enableMocking().then(() => {
   ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
     <React.StrictMode>


### PR DESCRIPTION
## Issue

- close #196 

## ✨ 구현한 기능
서버종료에 따라 gh-pages로 배포하도록 배포방식을 변경했습니다.

```yml
name: Frontend Pages Deploy

on:
  push:
    branches:
      - develop
      - main
    paths:
      - 'Frontend/**'
      - .github/**

  workflow_dispatch: # 수동 실행을 위한 설정

jobs:
  deploy:
    runs-on: ubuntu-latest
    defaults:
      run:
        working-directory: ./Frontend
    permissions:
      contents: write
    concurrency:
      group: ${{ github.workflow }}-${{ github.ref }}
      cancel-in-progress: true

    steps:
      - name: Use repository source
        uses: actions/checkout@v3

      - name: Setup Node.js
        uses: actions/setup-node@v3
        with:
          node-version: 20.11.1

      - name: Install pnpm
        uses: pnpm/action-setup@v3
        with:
          version: 9.1.3

      - name: Cache dependencies
        id: cache
        uses: actions/cache@v3
        with:
          path: '**/node_modules'
          key: ${{ runner.os }}-node-${{ hashFiles('**/pnpm-lock.yaml') }}
          restore-keys: |
            ${{ runner.os }}-node-

      - name: Install Dependencies
        if: steps.cache.outputs.cache-hit != 'true'
        run: pnpm install --no-frozen-lockfile

      - name: Set PUBLIC_URL
        run: |
          PUBLIC_URL=$(echo $GITHUB_REPOSITORY | sed -r 's/^.+\/(.+)$/\/\1\//')
          echo PUBLIC_URL=$PUBLIC_URL > .env

      - name: Create .env
        run: |
          echo "BASE_URL=${{ secrets.BASE_URL }}" >> .env
          echo "GOOGLE_ANALYTICS_ID=${{ secrets.GOOGLE_ANALYTICS_ID }}" >> .env

      - name: Build App
        run: |
          pnpm build
          cp ./Frontend/dist/index.html ./Frontend/dist/404.html

      - name: Build Storybook
        run: |
          pnpm build:sb
          mv ./Frontend/storybook-static ./Frontend/dist/storybook

      - name: Deploy To 'gh-pages' Branch
        uses: peaceiris/actions-gh-pages@v3
        with:
          github_token: ${{ secrets.GITHUB_TOKEN }}
          publish_dir: ./Frontend/dist

```
- [x] 실제 데이터 대신 mock데이터를 사용하도록 설정했습니다.

## 기타 수정 사항
1. mockServiceWorker 경로 설정
```tsx
// index.tsx
const enableMocking = async () => {
  // if (process.env.NODE_ENV !== 'development') {
  //   return;
  // }

  const { worker } = await import('./mocks/browser');
  return worker.start({
    serviceWorker: {
      url: '/INDIE-RO/mockServiceWorker.js',
    },
  });
};
```

2. router basename 설정
```tsx
// router.tsx
export const router = createBrowserRouter(
  [
    {
      path: '/',
      element: <App />,
      children: [
        {
          index: true,
          element: <IntroPage />,
        },
       ...
        {
          path: PATH.LOADING,
          element: <LoadingPage />,
        },
      ],

      errorElement: <div>error page</div>,
    },
  ],
  {
    basename: process.env.PUBLIC_URL, // 추가
  },
);
```

3. package.json에 homepage 설정
```tsx
// package.json
{
  "name": "Frontend",
  "version": "1.0.0",
  "main": "index.js",
  "homepage": "https://indie-ro.github.io/INDIE-RO/", // 추가
  ...
}
```

4. webpack.config.js publicPath 설정
```tsx
// webpack.config.js
...
  output: {
    path: path.resolve(__dirname, 'dist'),
    filename: '[name].[chunkhash].js',
    publicPath: '/INDIE-RO/', // 추가
  },
...
```

5. custom 도메인 설정
<img width="583" alt="image" src="https://github.com/user-attachments/assets/608f5c63-1220-4952-8709-1c10e3a987bd">

<img width="1131" alt="image" src="https://github.com/user-attachments/assets/fff8d767-829c-49fc-966a-e9d6b1f34f13">

<img width="756" alt="image" src="https://github.com/user-attachments/assets/c54271b9-3923-428b-8272-871ce2aac535">


## 추가 변경사항
커스텀 도메인 설정하면서 경로가 안 맞아서 위에 기타 수정 사항 1~4번은 다시 원래 코드로 변경했습니다!
