### PR TITLE
뒤로가기 시 이전 스크롤 위치로 이동하는 기능 구현

### DIFF
--- a/Frontend/src/hooks/@common/index.ts
+++ b/Frontend/src/hooks/@common/index.ts
@@ -4,4 +4,5 @@ export { default as useDebounce } from './useDebounce';
 export { default as useEasyNavigate } from './useEasyNavigate';
 export { default as useFunnel } from './useFunnel';
 export { default as useScrollRestoration } from './useScrollRestoration';
+export { default as useThrottle } from './useThrottle';
 export { default as useValidQueryParams } from './useValidQueryParams';

--- a/Frontend/src/hooks/@common/index.ts
+++ b/Frontend/src/hooks/@common/index.ts
@@ -3,4 +3,5 @@ export { default as useContextInScope } from './useContextInScope';
 export { default as useDebounce } from './useDebounce';
 export { default as useEasyNavigate } from './useEasyNavigate';
 export { default as useFunnel } from './useFunnel';
+export { default as useScrollRestoration } from './useScrollRestoration';
 export { default as useValidQueryParams } from './useValidQueryParams';

--- a/Frontend/src/hooks/@common/useScrollRestoration.ts
+++ b/Frontend/src/hooks/@common/useScrollRestoration.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from 'react';
+import { useNavigationType } from 'react-router-dom';
+
+const NAVIGATION_TYPE = {
+  POP: 'POP',
+  PUSH: 'PUSH',
+  RELOAD: 'RELOAD',
+} as const;
+
+const useScrollRestoration = () => {
+  const navigationType = useNavigationType();
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  const SESSION_STORAGE_KEY = {
+    SCROLL_Y: 'SCROLL_Y',
+  } as const;
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (scrollRef.current) {
+        sessionStorage.setItem(
+          SESSION_STORAGE_KEY.SCROLL_Y,
+          scrollRef.current.scrollTop.toString(),
+        );
+      }
+    };
+
+    scrollRef.current?.addEventListener('scroll', handleScroll);
+
+    return () => {
+      scrollRef.current?.removeEventListener('scroll', handleScroll);
+    };
+  }, [scrollRef]);
+
+  useEffect(() => {
+    if (navigationType === NAVIGATION_TYPE.POP) {
+      const savedScrollY = sessionStorage.getItem(SESSION_STORAGE_KEY.SCROLL_Y);
+
+      if (savedScrollY && scrollRef.current) {
+        scrollRef.current.scrollTop = parseInt(savedScrollY, 10);
+      }
+    }
+  }, [navigationType]);
+
+  return { scrollRef };
+};
+
+export default useScrollRestoration;

--- a/Frontend/src/hooks/@common/useScrollRestoration.ts
+++ b/Frontend/src/hooks/@common/useScrollRestoration.ts
@@ -9,14 +9,14 @@ const NAVIGATION_TYPE = {
   RELOAD: 'RELOAD',
 } as const;
 
+const SESSION_STORAGE_KEY = {
+  SCROLL_Y: 'SCROLL_Y',
+} as const;
+
 const useScrollRestoration = () => {
   const navigationType = useNavigationType();
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const throttle = useThrottle();
-
-  const SESSION_STORAGE_KEY = {
-    SCROLL_Y: 'SCROLL_Y',
-  } as const;
 
   useEffect(() => {
     const handleScrollWithThrottle = throttle(() => {

--- a/Frontend/src/hooks/@common/useScrollRestoration.ts
+++ b/Frontend/src/hooks/@common/useScrollRestoration.ts
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from 'react';
 import { useNavigationType } from 'react-router-dom';
 
+import useThrottle from '@/hooks/@common/useThrottle';
+
 const NAVIGATION_TYPE = {
   POP: 'POP',
   PUSH: 'PUSH',
@@ -10,25 +12,26 @@ const NAVIGATION_TYPE = {
 const useScrollRestoration = () => {
   const navigationType = useNavigationType();
   const scrollRef = useRef<HTMLDivElement | null>(null);
+  const throttle = useThrottle();
 
   const SESSION_STORAGE_KEY = {
     SCROLL_Y: 'SCROLL_Y',
   } as const;
 
   useEffect(() => {
-    const handleScroll = () => {
+    const handleScrollWithThrottle = throttle(() => {
       if (scrollRef.current) {
         sessionStorage.setItem(
           SESSION_STORAGE_KEY.SCROLL_Y,
           scrollRef.current.scrollTop.toString(),
         );
       }
-    };
+    });
 
-    scrollRef.current?.addEventListener('scroll', handleScroll);
+    scrollRef.current?.addEventListener('scroll', handleScrollWithThrottle);
 
     return () => {
-      scrollRef.current?.removeEventListener('scroll', handleScroll);
+      scrollRef.current?.removeEventListener('scroll', handleScrollWithThrottle);
     };
   }, [scrollRef]);
 

--- a/Frontend/src/hooks/@common/useThrottle.ts
+++ b/Frontend/src/hooks/@common/useThrottle.ts
@@ -1,0 +1,24 @@
+import { useCallback, useRef } from 'react';
+
+const useThrottle = () => {
+  const isWaiting = useRef(false);
+
+  /** 스크롤 위치를 기록하는 경우 delay 50이하일 때 가장 원활하여 50을 기본값으로 설정 */
+  return useCallback(
+    (callback: (...arg: any) => void, delay: number = 50) =>
+      (...arg: any) => {
+        if (!isWaiting.current) {
+          callback(...arg);
+
+          isWaiting.current = true;
+
+          setTimeout(() => {
+            isWaiting.current = false;
+          }, delay);
+        }
+      },
+    [],
+  );
+};
+
+export default useThrottle;

--- a/Frontend/src/mocks/handlers/policyHandlers.js
+++ b/Frontend/src/mocks/handlers/policyHandlers.js
@@ -67,7 +67,7 @@ const policyHandlers = [
   http.get(BASE_URL + '/api' + API_PATH.POLICY_LIST, async ({ request }) => {
     const url = new URL(request.url);
     const sortBy = parseInt(url.searchParams.get('sortBy'));
-    const categoryId = parseInt(url.searchParams.get('categoryId')) ?? 1;
+    const categoryId = parseInt(url.searchParams.get('categoryId') ?? 1);
     const openingStatusId = parseInt(url.searchParams.get('openingStatusId'));
     const regionIds = url.searchParams.get('regionIds')?.split(',').map(parseInt);
 

--- a/Frontend/src/mocks/handlers/policyHandlers.js
+++ b/Frontend/src/mocks/handlers/policyHandlers.js
@@ -13,7 +13,7 @@ const policyHandlers = [
   /* 정책 검색 결과 조회 */
   http.get(BASE_URL + '/api' + API_PATH.POLICY_SEARCH, async ({ request }) => {
     const url = new URL(request.url);
-    const sortBy = parseInt(url.searchParams.get('sortBy'));
+    const sortBy = parseInt(url.searchParams.get('sortBy') ?? 1);
     const searchQuery = url.searchParams.get('query') ?? '';
 
     const { policies, ...restResponse } = policiesResponse;
@@ -37,7 +37,7 @@ const policyHandlers = [
   /* 맞춤 정책목록 조회 */
   http.get(BASE_URL + '/api' + API_PATH.CUSTOM_INFO, async ({ request }) => {
     const url = new URL(request.url);
-    const sortBy = parseInt(url.searchParams.get('sortBy'));
+    const sortBy = parseInt(url.searchParams.get('sortBy') ?? 1);
     const categoryIds = url.searchParams.get('categoryIds')?.split(',').map(parseInt);
     const regionIds = url.searchParams.get('regionIds')?.split(',').map(parseInt);
 
@@ -66,7 +66,7 @@ const policyHandlers = [
   /* 정책목록 조회 */
   http.get(BASE_URL + '/api' + API_PATH.POLICY_LIST, async ({ request }) => {
     const url = new URL(request.url);
-    const sortBy = parseInt(url.searchParams.get('sortBy'));
+    const sortBy = parseInt(url.searchParams.get('sortBy') ?? 1);
     const categoryId = parseInt(url.searchParams.get('categoryId') ?? 1);
     const openingStatusId = parseInt(url.searchParams.get('openingStatusId'));
     const regionIds = url.searchParams.get('regionIds')?.split(',').map(parseInt);

--- a/Frontend/src/pages/CustomInfoPage.tsx
+++ b/Frontend/src/pages/CustomInfoPage.tsx
@@ -1,13 +1,14 @@
-import { Suspense, useRef } from 'react';
+import { Suspense } from 'react';
 
 import styled from '@emotion/styled';
 
 import { BasicLayout, ScrollButton } from '@/components/@common';
 import { CustomInfo, PolicyList } from '@/components/Policy';
+import { useScrollRestoration } from '@/hooks/@common';
 import theme from '@/styles/theme';
 
 function CustomInfoPage() {
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const { scrollRef } = useScrollRestoration();
 
   return (
     <BasicLayout>

--- a/Frontend/src/pages/PolicyListPage.tsx
+++ b/Frontend/src/pages/PolicyListPage.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useRef } from 'react';
+import { Suspense } from 'react';
 
 import styled from '@emotion/styled';
 
@@ -11,19 +11,18 @@ import { usePolicySort } from '@/components/Policy/PolicyList/PolicyList.hook';
 import { useSortMetaQuery } from '@/components/Policy/PolicyList/PolicyList.query';
 import { CATEGORY_TYPE, TAB_ID_BY_VARIANT } from '@/constants/common';
 import { PATH } from '@/constants/path';
-import { useEasyNavigate } from '@/hooks/@common';
+import { useEasyNavigate, useScrollRestoration } from '@/hooks/@common';
 import { usePolicySearch } from '@/pages/PolicySearchPage/PolicySearch.hook';
 import { generateQueryString } from '@/utils/route';
 
 function PolicyListPage() {
   const { navigate } = useEasyNavigate();
+  const { scrollRef } = useScrollRestoration();
   const { selectedTabMenu, handleTabMenuClick } = useTabMenu(CATEGORY_TYPE.JOB);
 
   const { sortMeta } = useSortMetaQuery();
   const { changeSortBy } = usePolicySort();
   const { search, changeSearchQuery } = usePolicySearch();
-
-  const scrollRef = useRef<HTMLDivElement>(null);
 
   const changeTab = (selectedMenu: TabVariant) => {
     handleTabMenuClick(selectedMenu);

--- a/Frontend/src/pages/PolicySearchPage/PolicySearchPage.tsx
+++ b/Frontend/src/pages/PolicySearchPage/PolicySearchPage.tsx
@@ -1,10 +1,10 @@
-import { Suspense, useRef } from 'react';
+import { Suspense } from 'react';
 
 import styled from '@emotion/styled';
 
 import { BasicLayout, ScrollButton, SearchBar } from '@/components/@common';
 import { PolicyList } from '@/components/Policy';
-import { useValidQueryParams } from '@/hooks/@common';
+import { useScrollRestoration, useValidQueryParams } from '@/hooks/@common';
 import { usePolicySearch } from '@/pages/PolicySearchPage/PolicySearch.hook';
 
 import { SEARCH_KEYWORD_FOR_SEARCH, SearchKeywordForSearch } from './PolicySearch.api';
@@ -14,7 +14,7 @@ function PolicySearchPage() {
   const { search, changeSearchQuery } = usePolicySearch();
   const { query } = useValidQueryParams<SearchKeywordForSearch>(SEARCH_KEYWORD_FOR_SEARCH);
 
-  const scrollRef = useRef<HTMLDivElement>(null);
+  const { scrollRef } = useScrollRestoration();
 
   return (
     <BasicLayout>


### PR DESCRIPTION
## Issue

- close #194

## ✨ 구현한 기능

### 실행화면(면접 정장대여 정책 클릭)
![이전_스크롤_위치_기억](https://github.com/user-attachments/assets/2081c4a0-3e02-4f1d-aac8-b11bb7dc7888)


정책 상세를 보다가 뒤로가기를 눌렀을 때 스크롤 위치가 다시 처음으로 돌아가 불편하다는 피드백을 받아
**뒤로가기 시 이전 스크롤 위치로 이동**하는 기능을 추가했습니다.

- [x] `useScrollRestoration` 커스텀 훅 구현 및 적용
- [x] `useThrottle` 커스텀 훅 구현 및 적용

### useScrollRestoration
스크롤 이벤트가 발생할 때마다 스크롤 위치를 `sessionStorage`에 저장하고
정책 상세 페이지에서 뒤로가기 시, 이전 스크롤 위치를 `sessionStorage`에서 가져와 이동하는 방식으로 구현하였습니다.

처음엔 정책 아이템 클릭 시 스크롤 위치를 저장하려고 하였으나,
`window.scrollY`가 아닌 정책 아이템들을 담고있는 실제 컨테이너(`overflow-y: scroll` 속성이 설정된)의 스크롤 위치(`scrollTop`)에 접근해야했습니다.
그런데 이 컨테이너는 정책 아이템과 다른 컴포넌트에 있었고,,
`props`로 해당 컨테이너의 `Ref`를 전달해봤지만 `undefined`가 뜨는 문제가 있었어요.

그래서 정책 아이템 클릭 대신 -> 스크롤 이벤트 발생할 때 스크롤 위치를 저장했습니다.

### useThrottle
![스크롤이벤트_문제점](https://github.com/user-attachments/assets/b7ce6d6a-3712-44df-a269-50a4b6463ba7)

스크롤 이벤트의 경우 마우스를 조금만 움직여도 많은 수의 이벤트가 발생합니다.

그래서 `throttle`을 적용하여 일정 시간(`delay`) 동안 연속적으로 발생하는 스크롤 이벤트 중 첫번째 이벤트만 실행하도록 하기 위해 `useThrottle` 커스텀 훅을 추가했습니다.

콜백함수를 실행할지 기다릴지를 판별하는 플래그 변수 `isWaiting`를 만들고
`setTimeout`을 이용하여 `delay`시간이 지나면 `isWaiting`을 `false`로 설정하여 콜백함수를 실행하도록 구현했어요.

`delay` 값은 너무 크게 주면 스크롤 위치를 저장하는 주기가 길어져 제대로 동작하지 않기 때문에 기본값은 50으로 설정했습니다.

**throttle 적용 전 3초 스크롤 했을 때 이벤트 발생 건수: 264**
<img width="1275" alt="쓰로틀링_적용_전_3초_스크롤_264" src="https://github.com/user-attachments/assets/77754957-e2d7-493d-97bd-73a9b98fe7da">

**throttle 적용 후 3초 스크롤 했을 때 이벤트 발생 건수: 34**
<img width="1281" alt="쓰로틀링_적용_후_3초_스크롤_34" src="https://github.com/user-attachments/assets/dbd525b2-8312-4d97-bcab-beeceb06d1a2">

