### PR TITLE
fix: 정책목록의 카테고리 탭을 쿼리파라미터와 동기화되도록 수정

### DIFF
--- a/Frontend/src/constants/common.ts
+++ b/Frontend/src/constants/common.ts
@@ -10,6 +10,15 @@ export const CATEGORY_TYPE = {
   WELFARE: 'welfare',
 } as const;
 
+type CategoryType = (typeof CATEGORY_TYPE)[keyof typeof CATEGORY_TYPE];
+
+export const CATEGORY_TYPE_BY_ID: Record<string, CategoryType> = {
+  1: CATEGORY_TYPE.JOB,
+  2: CATEGORY_TYPE.HOUSING,
+  3: CATEGORY_TYPE.EDUCATION,
+  4: CATEGORY_TYPE.WELFARE,
+};
+
 // description~otherInfo는 백엔드서버로부터 메타데이터를 조회하지 않으므로 id가 없으나 임의로 지정함
 export const TAB_ID_BY_VARIANT: Record<TabVariant, number> = {
   job: 1,

--- a/Frontend/src/pages/PolicyListPage.tsx
+++ b/Frontend/src/pages/PolicyListPage.tsx
@@ -7,18 +7,20 @@ import { TOTAL_POLICY_TAB_MENUS } from '@/components/@common/TabMenu/constants';
 import { TabVariant } from '@/components/@common/TabMenu/type';
 import useTabMenu from '@/components/@common/TabMenu/useTabMenu';
 import { PolicyFilterBottomSheet, PolicyList, PolicyListContainer } from '@/components/Policy';
+import { KEYWORD_FOR_ALL, KeywordForAll } from '@/components/Policy/PolicyList/PolicyList.api';
 import { usePolicySort } from '@/components/Policy/PolicyList/PolicyList.hook';
 import { useSortMetaQuery } from '@/components/Policy/PolicyList/PolicyList.query';
-import { CATEGORY_TYPE, TAB_ID_BY_VARIANT } from '@/constants/common';
+import { CATEGORY_TYPE_BY_ID, TAB_ID_BY_VARIANT } from '@/constants/common';
 import { PATH } from '@/constants/path';
-import { useEasyNavigate, useScrollRestoration } from '@/hooks/@common';
+import { useEasyNavigate, useScrollRestoration, useValidQueryParams } from '@/hooks/@common';
 import { usePolicySearch } from '@/pages/PolicySearchPage/PolicySearch.hook';
 import { generateQueryString } from '@/utils/route';
 
 function PolicyListPage() {
   const { navigate } = useEasyNavigate();
   const { scrollRef } = useScrollRestoration();
-  const { selectedTabMenu, handleTabMenuClick } = useTabMenu(CATEGORY_TYPE.JOB);
+  const { categoryId } = useValidQueryParams<KeywordForAll>(KEYWORD_FOR_ALL);
+  const { selectedTabMenu, handleTabMenuClick } = useTabMenu(CATEGORY_TYPE_BY_ID[categoryId ?? 1]);
 
   const { sortMeta } = useSortMetaQuery();
   const { changeSortBy } = usePolicySort();


### PR DESCRIPTION
## Issue

- close #195 

## ✨ 구현한 기능

정책상세에서 뒤로가기 시 쿼리파라미터의 카테고리 정보와 화면에 선택된 카테고리 정보가 동기화되지 않는 문제가 있습니다.
(e.g. 쿼리 파라미터에 있는 정책 아이디는 3(교육)인데 1(일자리)번 카테고리가 선택된 것처럼 보임)

정책목록에서 현재 쿼리파라미터 값을 가져와서 정책 탭메뉴를 초기화하여 두 정보가 일치하도록 수정했습니다.

### Before
![image](https://github.com/user-attachments/assets/b9265ad3-46cb-4e2b-bfbf-470f02a2c724)

### After
![정책카테고리_쿼리파라미터_동기화](https://github.com/user-attachments/assets/67cc39a0-51a1-483e-ad29-f60ccfd9cc5e)